### PR TITLE
[fix] 삭제된 user 엔티티 import문 삭제 #22

### DIFF
--- a/src/main/java/prestudy/team4/board/controller/S3Controller.java
+++ b/src/main/java/prestudy/team4/board/controller/S3Controller.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import prestudy.team4.board.domain.User;
 import prestudy.team4.board.dto.S3UrlDto;
 import prestudy.team4.board.service.S3Service;
 


### PR DESCRIPTION
- S3Controller에서 삭제된 user 엔티티 import문이 존재해 삭제했습니다~